### PR TITLE
Fix site in installer part of index.smd

### DIFF
--- a/content/index.smd
+++ b/content/index.smd
@@ -30,7 +30,7 @@ This is a programmer's text editor. It is under active development, but usually 
 ## 📦 Installation
 
 ### Installer
-``` curl -fsSL https://www.flow-editor.dev/install | sh ```
+``` curl -fsSL https://www.flow-control.dev/install | sh ```
 
 ### Prebuilt Binaries
 - Stable: [Releases](https://github.com/neurocyte/flow/releases)


### PR DESCRIPTION
This pull request includes a minor change to the `content/index.smd` file. The change updates the URL in the installation instructions to reflect the new domain for the installer.

* [`content/index.smd`](diffhunk://#diff-29722993e4f5b88b2ece838f2b439355b612937801de553e0cce9618b335bcccL33-R33): Updated the installation URL from `flow-editor.dev` to `flow-control.dev`.