### PR TITLE
Remove "www." from website in index.smd

### DIFF
--- a/content/index.smd
+++ b/content/index.smd
@@ -30,7 +30,7 @@ This is a programmer's text editor. It is under active development, but usually 
 ## 📦 Installation
 
 ### Installer
-``` curl -fsSL https://www.flow-control.dev/install | sh ```
+``` curl -fsSL https://flow-control.dev/install | sh ```
 
 ### Prebuilt Binaries
 - Stable: [Releases](https://github.com/neurocyte/flow/releases)

--- a/content/index.smd
+++ b/content/index.smd
@@ -30,7 +30,7 @@ This is a programmer's text editor. It is under active development, but usually 
 ## 📦 Installation
 
 ### Installer
-``` curl -fsSL https://www.flow-editor.dev/install | sh ```
+``` curl -fsSL https://www.flow-control.dev/install | sh ```
 
 ### Prebuilt Binaries
 - Stable: [Releases](https://github.com/neurocyte/flow/releases)


### PR DESCRIPTION
Apparently i dont know how websites work! :sob:

This pull request includes a minor update to the installation instructions in the `content/index.smd` file. The change corrects the URL used in the curl command for installation.

* [`content/index.smd`](diffhunk://#diff-29722993e4f5b88b2ece838f2b439355b612937801de553e0cce9618b335bcccL33-R33): Updated the URL in the curl command from `https://www.flow-control.dev/install` to `https://flow-control.dev/install`.